### PR TITLE
Fix complete breakage on 5.6 due to invalid max_hp

### DIFF
--- a/arrow.lua
+++ b/arrow.lua
@@ -38,7 +38,7 @@ minetest.register_entity('nextgen_bows:arrow_entity', {
 		selectionbox = {0, 0, 0, 0, 0, 0},
 		physical = false,
 		textures = {'air'},
-		hp_max = 0.5
+		hp_max = 1
 	},
 
 	on_activate = function(self, staticdata)


### PR DESCRIPTION
Arrows will be removed immediately on 5.6, even before on activate is called. This mod is currently unusable on 5.6.