### PR TITLE
Add player_monoids Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Currently includes a Wooden Bow and arrows.
 - farming (bow and recipes)
 - 3d_armor (calculates damage including the armor)
 - playerphysics (force sneak when holding charged bow)
+- player_monoids (force sneak when holding charged bow)
 
 ## License:
 

--- a/init.lua
+++ b/init.lua
@@ -329,6 +329,8 @@ minetest.register_globalstep(function(dtime)
 			if item == 'nextgen_bows:bow_wood_charged' and not nextgen_bows.player_bow_sneak[name].sneak then
 				if minetest.get_modpath('playerphysics') then
 					playerphysics.add_physics_factor(player, 'speed', 'nextgen_bows:bow_wood_charged', 0.25)
+				elseif minetest.get_modpath('player_monoids') then
+					player_monoids.speed:add_change(player, 0.25, 'nextgen_bows:bow_wood_charged')
 				end
 
 				nextgen_bows.player_bow_sneak[name].sneak = true
@@ -336,6 +338,8 @@ minetest.register_globalstep(function(dtime)
 			elseif item ~= 'nextgen_bows:bow_wood_charged' and nextgen_bows.player_bow_sneak[name].sneak then
 				if minetest.get_modpath('playerphysics') then
 					playerphysics.remove_physics_factor(player, 'speed', 'nextgen_bows:bow_wood_charged')
+				elseif minetest.get_modpath('player_monoids') then
+					player_monoids.speed:del_change(player, 'nextgen_bows:bow_wood_charged')
 				end
 
 				nextgen_bows.player_bow_sneak[name].sneak = false

--- a/mod.conf
+++ b/mod.conf
@@ -1,7 +1,7 @@
 name = nextgen_bows
 description = Adds bow and arrows to Minetest.
 depends =
-optional_depends = default, farming, 3d_armor, hbhunger, mesecons, playerphysics
+optional_depends = default, farming, 3d_armor, hbhunger, mesecons, playerphysics, player_monoids
 min_minetest_version = 5.0
 
 title = NextGen Bows


### PR DESCRIPTION
Adds support for `player_monoids`. `x_bows` was used as a reference.